### PR TITLE
Update the scripts for Picard 2.0+

### DIFF
--- a/unicode-normalisation.py
+++ b/unicode-normalisation.py
@@ -2,7 +2,7 @@ PLUGIN_NAME = 'NFC/NFD functions'
 PLUGIN_AUTHOR = ''
 PLUGIN_DESCRIPTION = 'Adds $nfc(text) and $nfd(text) functions for converting strings to NFC or NFD'
 PLUGIN_VERSION = "0.1"
-PLUGIN_API_VERSIONS = ["1.0"]
+PLUGIN_API_VERSIONS = ["1.0", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 
 from picard.script import register_script_function
 import unicodedata


### PR DESCRIPTION
The MusicBrainz API switched to a JSON API since version 2, so the `use-pseudo-releases.py` plugin doesn't work anymore.

This PR updates the scripts to make them work with newer versions of Picard.

Tested with MusicBrainz Picard 2.7.1.

Resolves #1.